### PR TITLE
Add botbalance.o rule to Makefile.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.ccls-cache/
+src/*.o
+imprimis_gameserver

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,8 +5,8 @@ INCLUDES= -Ienet/include -Ishared
 
 all: imprimis_gameserver
 
-imprimis_gameserver : command.o demo.o server.o cserver.o mapcontrol.o stream.o tools.o
-		g++ $(CXXFLAGS) $(INCLUDES) -o imprimis_gameserver command.o server.o cserver.o mapcontrol.o stream.o tools.o demo.o -Lenet -lenet -lz
+imprimis_gameserver : command.o demo.o server.o cserver.o mapcontrol.o stream.o tools.o botbalance.o
+		g++ $(CXXFLAGS) $(INCLUDES) -o imprimis_gameserver command.o server.o cserver.o mapcontrol.o stream.o tools.o demo.o botbalance.o -Lenet -lenet -lz
 
 command.o :
 		g++ $(CXXFLAGS) $(INCLUDES) -c command.cpp
@@ -32,5 +32,8 @@ stream.o : tools.h
 tools.o :
 		g++ $(CXXFLAGS) $(INCLUDES) -c tools.cpp
 
+botbalance.o :
+		g++ $(CXXFLAGS) $(INCLUDES) -c botbalance.cpp
+
 clean:
-		rm -f command.o server.o demo.o worldio.o cserver.o crypto.o mapcontrol.o stream.o tools.o imprimis_gameserver
+		rm -f command.o server.o demo.o worldio.o cserver.o crypto.o mapcontrol.o stream.o tools.o botbalance.o imprimis_gameserver


### PR DESCRIPTION
The imprimis-gameserver could not compile because it used a function
from `botbalance.cpp`.

https://github.com/project-imprimis/imprimis-gameserver/blob/c489e801e13580259d5410722e1970863145500f/src/cserver.cpp#L2094

This commit fixes that by adding a compilation rule for `botbalance.o`
to the Makefile.